### PR TITLE
Honor addTrailingSlashesToUrls also for baseUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # HOMM XML Sitemap Changelog
 
+## 1.0.2 - 2022-11-24
+
+- Honor addTrailingSlashesToUrls also for baseUrl
+
 ## 1.0.1 - 2022-07-26
 
 - fixed per entry indexing flag

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "homm/hommxmlsitemap",
     "description": "Craft CMS Plugin to provide and manage XML Sitemap",
     "type": "craft-plugin",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -221,7 +221,7 @@ class SitemapController extends Controller
             $path = ($uri === '__home__') ? '' : $uri;
             $url = UrlHelper::siteUrl($path, null, null, $siteId);
             // If the addTrailingSlashesToUrls is set to false, then ensure there is no / at the end.
-            if(!Craft::$app->request->generalConfig->addTrailingSlashesToUrls) {
+            if (!Craft::$app->config->general->addTrailingSlashesToUrls) {
                 $url = rtrim($url, '/');
             }
             return $url;

--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -219,7 +219,12 @@ class SitemapController extends Controller
     {
         if ($uri !== null) {
             $path = ($uri === '__home__') ? '' : $uri;
-            return UrlHelper::siteUrl($path, null, null, $siteId);
+            $url = UrlHelper::siteUrl($path, null, null, $siteId);
+            // If the addTrailingSlashesToUrls is set to false, then ensure there is no / at the end.
+            if(!Craft::$app->request->generalConfig->addTrailingSlashesToUrls) {
+                $url = rtrim($url, '/');
+            }
+            return $url;
         }
 
         return null;


### PR DESCRIPTION
Ensure that no trailing slash is added to the base site URL when generating the sitemap – only when addTrailingSlashesToUrls is set to false. For multisite setups, this avoids having redirections from "yoursite.com/en/" to "yoursite.com/en" in the sitemap.